### PR TITLE
update precedent section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A new `Promise.isPromise` predicate that exposes the result of the [`IsPromise`]
 
 ## Precedent
 
-[`Error.isError`](https://github.com/tc39/proposal-is-error) does a similar brand check for native `Error` objects.
+[`Error.isError`](https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-error.iserror) does a similar check for `Error` objects that have magic `stack` behaviour. [`Array.isArray`](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.isarray) does a similar check for `Array` objects that have magic `length` behaviour.
 
 ## Membrane transparency
 


### PR DESCRIPTION
1. ~it's not a brand check like isError or isArray, it's just a check~
1. link to isError in 262, it's no longer a proposal
1. add reference to `Array.isArray` as well
1. mention the associated magic behaviour for each of the precedent-setting methods